### PR TITLE
Testing Data Tagging explanation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Ouranos inc.
+Copyright (c) 2020-2023 Ouranos inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # xclim-testdata
-NetCDF example files used for the testing suite of Xclim
+NetCDF example files used for the testing suite of `xclim`
 
 ## Contributing
-
 In order to add a new dataset to the `xclim` testing data, please ensure you perform the following:
 
 1. Create a new branch: `git checkout -b my_new_testdata_branch`
@@ -14,7 +13,6 @@ In order to add a new dataset to the `xclim` testing data, please ensure you per
 To modify an existing dataset, be sure to remove the existing checksum file before running the `make_check_sums.py` script.
 
 If you wish to perform preliminary tests against the dataset using `xclim`, this can be done with the following procedure:
-
 ```python
 from xclim.testing import open_dataset
 
@@ -25,3 +23,37 @@ ds = open_dataset(
     branch="my_new_testdata_branch"
 )
 ```
+
+> **Note**
+> The following options only work for branches based on `Ouranosinc/xclim-testdata`, not forks.
+
+If you wish to run the entire `xclim` testing suite locally against your branch, this can be set via an environment variable:
+```shell
+$ export XCLIM_TESTDATA_BRANCH="my_new_testdata_branch"
+
+$ pytest xclim
+# or, alternatively:
+$ tox
+```
+
+If you wish to run the entire `xclim` testing suite on the `Ouranosinc/xclim` GitHub Workflows (CI) against your branch,
+this can be set via an environment variable default in the `.github/workflows/main.yml` workflow configuration:
+```yaml
+env:
+  XCLIM_TESTDATA_BRANCH: my_new_testdata_branch
+```
+
+> **Note**
+> Be aware that modifying this variable to a value other than the latest tagged version of `xclim-testdata`
+> will trigger a GitHub Workflow that will block merging of your Pull Request until changes are effected.
+
+## Versioning
+When updating a dataset in `xclim-testdata` using a development branch and Pull Request, once changes have been merged
+to the `main` branch, you should tag a new version of `xclim-testdata`. The version tag of `xclim-testdata` is loosely tied
+to that of `xclim`, and should represent the `xclim` version (**stable**, i.e. version string not ending in `-dev`)
+that is compatible with `xclim-testdata`.
+
+> **Warning** 
+> In the event that multiple Pull Requests occur for `xclim-testdata` between two stable versions 
+> (e.g. one for `xclim @ 1.2.3-dev` and another for `xclim @ 1.2.5-dev`),
+> the `xclim-tesdata` tag (e.g. `xclim-testdata @ 1.3.0`) should be replaced with the commit reflecting the most recent changes.

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ env:
 ## Versioning
 When updating a dataset in `xclim-testdata` using a development branch and Pull Request, once changes have been merged
 to the `main` branch, you should tag a new version of `xclim-testdata`. The version tag of `xclim-testdata` is loosely tied
-to that of `xclim`, and should represent the `xclim` version (**stable**, i.e. version string not ending in `-dev`)
-that is compatible with `xclim-testdata`.
+to that of `xclim`, and should represent the `xclim` release (**stable**, i.e. version string not ending in `-dev`)
+that is compatible with the latest changes in `xclim-testdata`.
 
 > **Warning** 
-> In the event that multiple Pull Requests occur for `xclim-testdata` between two stable versions 
-> (e.g. one for `xclim @ 1.2.3-dev` and another for `xclim @ 1.2.5-dev`),
-> the `xclim-tesdata` tag (e.g. `xclim-testdata @ 1.3.0`) should be replaced with the commit reflecting the most recent changes.
+> In the event that multiple Pull Requests occur for `xclim-testdata` between two stable versions of `xclim`
+> (e.g. one for `v1.2.3-dev` and another for `v1.2.5-dev`), the `xclim-tesdata` tag (e.g. `v1.3.0`)
+> should be replaced with the commit reflecting the most recent changes.

--- a/README.md
+++ b/README.md
@@ -48,12 +48,7 @@ env:
 > will trigger a GitHub Workflow that will block merging of your Pull Request until changes are effected.
 
 ## Versioning
-When updating a dataset in `xclim-testdata` using a development branch and Pull Request, once changes have been merged
-to the `main` branch, you should tag a new version of `xclim-testdata`. The version tag of `xclim-testdata` is loosely tied
-to that of `xclim`, and should represent the `xclim` release (**stable**, i.e. version string not ending in `-dev`)
-that is compatible with the latest changes in `xclim-testdata`.
+When updating a dataset in `xclim-testdata` using a development branch and Pull Request,
+once changes have been merged to the `main` branch, you should tag a new version of `xclim-testdata`. 
 
-> **Warning** 
-> In the event that multiple Pull Requests occur for `xclim-testdata` between two stable versions of `xclim`
-> (e.g. one for `v1.2.3-dev` and another for `v1.2.5-dev`), the `xclim-tesdata` tag (e.g. `v1.3.0`)
-> should be replaced with the commit reflecting the most recent changes.
+The version tag of `xclim-testdata` should follow a [calendar versioning](https://calver.org/) scheme (i.e. version string follows from `YYYY.MM.DD`, without modifiers) reflecting the date of the tag creation.

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ env:
 When updating a dataset in `xclim-testdata` using a development branch and Pull Request,
 once changes have been merged to the `main` branch, you should tag a new version of `xclim-testdata`. 
 
-The version tag of `xclim-testdata` should follow a [calendar versioning](https://calver.org/) scheme (i.e. version string follows from `YYYY.MM.DD`, without modifiers) reflecting the date of the tag creation.
+The version tag of `xclim-testdata` should follow a [calendar versioning](https://calver.org/) scheme (i.e. version string follows from `YYYY.MM.DD-r#`) reflecting the date of the tag creation, with modifiers if required.


### PR DESCRIPTION
 - [ ] added a ``.md5`` checksum file generated with ``make_check_sums.py``  **Not Applicable**

This PR adds an explanation on how to best use development branches with `xclim`, whether they are for local (`pytest` or `tox`) or CI (`GitHub Actions`). This also explains how to properly tag the commit when making changes so that no warnings occur for developers and users wishing to test `xclim`.